### PR TITLE
fix: remove clearErrors useEffect causing infinite render loop (React…

### DIFF
--- a/src/components/calculators/dynamic/DynamicStepRenderer.tsx
+++ b/src/components/calculators/dynamic/DynamicStepRenderer.tsx
@@ -167,11 +167,6 @@ export default function DynamicStepRenderer({
   // hidden conditional required fields from blocking form submission
   const schema = useMemo(() => buildValidationSchema(visibleQuestions), [visibleQuestions]);
 
-  // Update the resolver dynamically when visible questions change
-  useEffect(() => {
-    form.clearErrors();
-  }, [schema, form]);
-
   // Update store when form values change
   useEffect(() => {
     if (!watchedValues) return;


### PR DESCRIPTION
… #185)

The useEffect that called form.clearErrors() on schema change created an
infinite loop: clearErrors -> re-render -> visibleQuestions change ->
schema change -> clearErrors -> repeat. This caused the entire /vloeren-leggen page to crash with React error #185 (max update depth).

Validation is already handled manually in handleSubmit, so clearErrors is unnecessary.