### PR TITLE
fix: remove calculatorSlug from all QuestionSection components

### DIFF
--- a/src/app/(root)/(routes)/overig/egaliseren/page.tsx
+++ b/src/app/(root)/(routes)/overig/egaliseren/page.tsx
@@ -171,7 +171,7 @@ export default function OverigEgaliserenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/gietvloeren/page.tsx
+++ b/src/app/(root)/(routes)/overig/gietvloeren/page.tsx
@@ -144,7 +144,7 @@ export default function OverigGietvloerenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/natuursteen-behandelen/page.tsx
+++ b/src/app/(root)/(routes)/overig/natuursteen-behandelen/page.tsx
@@ -143,7 +143,7 @@ export default function OverigNatuursteenbehandelenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/opslag/page.tsx
+++ b/src/app/(root)/(routes)/overig/opslag/page.tsx
@@ -147,7 +147,7 @@ export default function OverigOpslagPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/page.tsx
+++ b/src/app/(root)/(routes)/overig/page.tsx
@@ -23,7 +23,7 @@ function OverigPage() {
       <NatuursteenBehandelen />
       <Opslag />
       <RatingSection />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
     </div>
   );
 }

--- a/src/app/(root)/(routes)/overig/tegelen/page.tsx
+++ b/src/app/(root)/(routes)/overig/tegelen/page.tsx
@@ -172,7 +172,7 @@ export default function OverigTegelenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/vloer-verwijderen/page.tsx
+++ b/src/app/(root)/(routes)/overig/vloer-verwijderen/page.tsx
@@ -158,7 +158,7 @@ export default function OverigVloerverwijderenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/overig/vloerverwarming/page.tsx
+++ b/src/app/(root)/(routes)/overig/vloerverwarming/page.tsx
@@ -147,7 +147,7 @@ export default function OverigVloerverwarmingPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="overig" />
+      <QuestionSection />
 
       <RatingSection />
     </div>

--- a/src/app/(root)/(routes)/parketrenovatie/aanhelen-uitbreiden/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/aanhelen-uitbreiden/page.tsx
@@ -145,7 +145,7 @@ export default function ParketrenovatieAanhelenUitbreidenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/drevelen/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/drevelen/page.tsx
@@ -131,7 +131,7 @@ export default function ParketrenovatieDrevelenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/page.tsx
@@ -25,7 +25,7 @@ export default function ParketrenovatieVGroefFrezenPage() {
       <VgroefFrezen />
       <PlintenDeklijsten />
       <RatingSection />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
     </div>
   );
 }

--- a/src/app/(root)/(routes)/parketrenovatie/plinten-en-deklijsten/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/plinten-en-deklijsten/page.tsx
@@ -138,7 +138,7 @@ export default function ParketrenovatiePlintenEnDeklijstenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/reparatie/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/reparatie/page.tsx
@@ -114,7 +114,7 @@ export default function ParketrenovatieReparatiePage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/schuren-en-hardwaxen/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/schuren-en-hardwaxen/page.tsx
@@ -136,7 +136,7 @@ export default function ParketrenovatieSchurenEnHardwaxenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/schuren-en-lakken/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/schuren-en-lakken/page.tsx
@@ -137,7 +137,7 @@ export default function ParketrenovatieSchurenEnLakkenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/schuren-en-olien/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/schuren-en-olien/page.tsx
@@ -135,7 +135,7 @@ export default function ParketrenovatieSchurenEnOlienPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/schuren-en-polijsten/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/schuren-en-polijsten/page.tsx
@@ -136,7 +136,7 @@ export default function ParketrenovatieSchurenEnPolijstenPage() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/parketrenovatie/v-groef-frezen/page.tsx
+++ b/src/app/(root)/(routes)/parketrenovatie/v-groef-frezen/page.tsx
@@ -133,7 +133,7 @@ export default function Home() {
       />
       <WhatWaitingForCard {...whatWaitingForConfig} className="lg:py-28" />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="parketrenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/deurmat/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/deurmat/page.tsx
@@ -136,7 +136,7 @@ export default function StofferenDeurmatPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/droogloopmat/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/droogloopmat/page.tsx
@@ -134,7 +134,7 @@ export default function StofferenDroogloopmatPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/meubels/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/meubels/page.tsx
@@ -150,7 +150,7 @@ export default function StofferenMeubelsPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/reinigingsservice/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/reinigingsservice/page.tsx
@@ -138,7 +138,7 @@ export default function StofferenReinigingsservicePage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/rode-loper/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/rode-loper/page.tsx
@@ -142,7 +142,7 @@ export default function StofferenRodeloperPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/tapijt-verwijderen/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/tapijt-verwijderen/page.tsx
@@ -141,7 +141,7 @@ export default function StofferenTapijtVerwijderenPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/tapijttegels/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/tapijttegels/page.tsx
@@ -143,7 +143,7 @@ export default function StofferenTapijttegelsPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/trap/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/trap/page.tsx
@@ -146,7 +146,7 @@ export default function StofferenTrapPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/stofferen/vloer/page.tsx
+++ b/src/app/(root)/(routes)/stofferen/vloer/page.tsx
@@ -155,7 +155,7 @@ export default function StofferenVloerPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="stofferen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/bekleden-met-hout/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/bekleden-met-hout/page.tsx
@@ -147,7 +147,7 @@ export default function TraprenovatieBekledenMetHout() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/bekleden-met-laminaat/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/bekleden-met-laminaat/page.tsx
@@ -201,7 +201,7 @@ export default function TraprenovatieBekledenMetLaminaat() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/bekleden-met-linoleum/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/bekleden-met-linoleum/page.tsx
@@ -139,7 +139,7 @@ export default function TraprenovatieBekledenMetLinoleum() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/bekleden-met-pvc/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/bekleden-met-pvc/page.tsx
@@ -251,7 +251,7 @@ export default function TraprenovatieBekledenMetPVC() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/bekleden-met-tapijt/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/bekleden-met-tapijt/page.tsx
@@ -164,7 +164,7 @@ export default function TraprenovatieBekledenMetTapijt() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/acoustic/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/acoustic/page.tsx
@@ -158,7 +158,7 @@ export default function TraprenovatieBetonCireAcoustic() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/brut/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/brut/page.tsx
@@ -163,7 +163,7 @@ export default function TraprenovatieBetonCireBrut() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/croco/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/croco/page.tsx
@@ -162,7 +162,7 @@ export default function TraprenovatieBetonCireCroco() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/glamour-stuc/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/glamour-stuc/page.tsx
@@ -167,7 +167,7 @@ export default function TraprenovatieBetonCireGlamourStucPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/metal-stuc/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/metal-stuc/page.tsx
@@ -164,7 +164,7 @@ export default function TraprenovatieBetonCireMetalStuc() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/parel/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/parel/page.tsx
@@ -165,7 +165,7 @@ export default function TraprenovatieBetonCireMetalStuc() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/beton-cire/venetiaans/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/beton-cire/venetiaans/page.tsx
@@ -164,7 +164,7 @@ export default function TraprenovatieBetonCireVenetiaans() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/dichte-trap/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/dichte-trap/page.tsx
@@ -170,7 +170,7 @@ export default function TraprenovatieDichteTrap() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/open-trap/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/open-trap/page.tsx
@@ -197,7 +197,7 @@ export default function TraprenovatieOpenTrap() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/page.tsx
@@ -43,7 +43,7 @@ function TraprenovatiesPage() {
       <DichteTrap />
       <Verlichting />
       <RatingSection />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
     </div>
   );
 }

--- a/src/app/(root)/(routes)/traprenovatie/schuren-en-behandelen/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/schuren-en-behandelen/page.tsx
@@ -166,7 +166,7 @@ export default function TraprenovatieSchurenEnBehandelen() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/schuren-en-schilderen/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/schuren-en-schilderen/page.tsx
@@ -140,7 +140,7 @@ export default function TraprenovatieSchurenEnSchilderen() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/traprenovatie/verlichting/page.tsx
+++ b/src/app/(root)/(routes)/traprenovatie/verlichting/page.tsx
@@ -148,7 +148,7 @@ export default function TraprenovatieVerlichting() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="traprenovatie" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/bourgogne/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/bourgogne/page.tsx
@@ -145,7 +145,7 @@ export default function VloerenLeggenBourgognePage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/hexagon-&-3d/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/hexagon-&-3d/page.tsx
@@ -162,7 +162,7 @@ export default function VloerenLeggenHexagonEn3DPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/hongaarse-punt/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/hongaarse-punt/page.tsx
@@ -146,7 +146,7 @@ export default function VloerenLeggenHongaarsePuntPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/laminaat/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/laminaat/page.tsx
@@ -145,7 +145,7 @@ export default function VloerenLeggenLaminaatPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/linoleum/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/linoleum/page.tsx
@@ -152,7 +152,7 @@ export default function VloerenLeggenLinoleumPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/mozaiek-en-patroon/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/mozaiek-en-patroon/page.tsx
@@ -162,7 +162,7 @@ export default function VloerenLeggenMozaiekEnPatroonPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/page.tsx
@@ -38,7 +38,7 @@ function Page() {
       <Tapis />
       <Bourgogne />
       <RatingSection />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
     </div>
   );
 }

--- a/src/app/(root)/(routes)/vloeren-leggen/parket/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/parket/page.tsx
@@ -145,7 +145,7 @@ export default function VloerenLeggenParketPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/pvc-tegels/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/pvc-tegels/page.tsx
@@ -147,7 +147,7 @@ export default function VloerenLeggenPVCTegelsPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/pvc/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/pvc/page.tsx
@@ -145,7 +145,7 @@ export default function VloerenLeggenPVCPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/tapijt/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/tapijt/page.tsx
@@ -142,7 +142,7 @@ export default function VloerenLeggenTapijtPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/tapis/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/tapis/page.tsx
@@ -141,7 +141,7 @@ export default function VloerenLeggenTapisPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/visgraat/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/visgraat/page.tsx
@@ -144,7 +144,7 @@ export default function VloerenLeggenVisgraatPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/walvisgraat/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/walvisgraat/page.tsx
@@ -141,7 +141,7 @@ export default function VloerenLeggenWalvisgraatPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );

--- a/src/app/(root)/(routes)/vloeren-leggen/weense-punt/page.tsx
+++ b/src/app/(root)/(routes)/vloeren-leggen/weense-punt/page.tsx
@@ -148,7 +148,7 @@ export default function VloerenLeggenWeensePuntPage() {
         className="lg:py-28"
       />
       <FAQSection FAQs={FAQs} />
-      <QuestionSection calculatorSlug="vloeren-leggen" />
+      <QuestionSection />
       <RatingSection />
     </div>
   );


### PR DESCRIPTION
Remove hardcoded calculator slugs from all 60 QuestionSection instances so they show the category dropdown instead. Avoids "Calculator niet gevonden" errors and prevents store conflicts with Hero calculator.