### PR TITLE
feat(calculator): render question and option tooltips with green info…

### DIFF
--- a/src/components/calculators/Getters/InputGetter.tsx
+++ b/src/components/calculators/Getters/InputGetter.tsx
@@ -2,11 +2,13 @@
 
 import CustomInput from '@/components/custom/CustomInput';
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form';
+import InfoTooltip from '@/components/ui/info-tooltip';
 
 interface InputGetterProps {
   form: any;
   name: string;
   label: string;
+  tooltip?: string;
   placeholder?: string;
   type?: string;
   inputClassName?: string;
@@ -18,6 +20,7 @@ export default function InputGetter({
   form,
   name,
   label,
+  tooltip,
   placeholder = '',
   type = 'text',
   inputClassName = '',
@@ -31,8 +34,9 @@ export default function InputGetter({
       render={({ field, fieldState }) => (
         <FormItem className="flex flex-col gap-y-2">
           {/* Label */}
-          <FormLabel className="font-normal text-textBlack80 text-sm">
-            {label}
+          <FormLabel className="font-normal text-textBlack80 text-sm inline-flex items-center gap-1">
+            <span>{label}</span>
+            {tooltip && <InfoTooltip text={tooltip} />}
             <span className="text-red-500">*</span>
           </FormLabel>
 

--- a/src/components/calculators/Getters/MultiSelectDropdown.tsx
+++ b/src/components/calculators/Getters/MultiSelectDropdown.tsx
@@ -2,12 +2,14 @@ import { useFormContext } from 'react-hook-form';
 
 import ShadcnCustomMultiSelect from '@/components/custom/ShadcnCustomMultiSelect';
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form';
+import InfoTooltip from '@/components/ui/info-tooltip';
 import { Option } from '@/types';
 
 interface MultiSelectDropdownProps {
   data: Option[];
   name: string;
   label: string;
+  tooltip?: string;
   placeholder?: string;
   exclusiveOption?: string; // Exclusive option like "Nee"
   buttonClassName?: string;
@@ -20,6 +22,7 @@ export default function MultiSelectDropdown({
   data,
   name,
   label,
+  tooltip,
   placeholder = 'Choose an option(s)',
   exclusiveOption,
   buttonClassName,
@@ -77,8 +80,9 @@ export default function MultiSelectDropdown({
       name={name}
       render={({ field, fieldState }) => (
         <FormItem className="flex flex-col gap-y-1">
-          <FormLabel className="font-normal text-textBlack80 text-sm">
-            {label}
+          <FormLabel className="font-normal text-textBlack80 text-sm inline-flex items-center gap-1">
+            <span>{label}</span>
+            {tooltip && <InfoTooltip text={tooltip} />}
             <span className="text-red-500">*</span>
           </FormLabel>
 

--- a/src/components/calculators/Getters/SingleSelectDropdown.tsx
+++ b/src/components/calculators/Getters/SingleSelectDropdown.tsx
@@ -4,12 +4,14 @@ import { useFormContext } from 'react-hook-form';
 
 import CustomSingleSelect from '@/components/custom/CustomSingleSelect';
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form';
+import InfoTooltip from '@/components/ui/info-tooltip';
 import { Option } from '@/types';
 
 interface SingleSelectDropdownProps {
   data: Option[];
   name: string;
   label: string;
+  tooltip?: string;
   placeholder?: string;
   buttonClassName?: string;
   placeholderTextClassName?: string;
@@ -24,6 +26,7 @@ export default function SingleSelectDropdown({
   data,
   name,
   label,
+  tooltip,
   placeholder = 'Choose an option',
   buttonClassName,
   placeholderTextClassName,
@@ -44,8 +47,9 @@ export default function SingleSelectDropdown({
       name={name}
       render={({ field, fieldState }) => (
         <FormItem className="flex flex-col gap-y-1">
-          <FormLabel className="font-normal text-textBlack80 text-sm">
-            {label}
+          <FormLabel className="font-normal text-textBlack80 text-sm inline-flex items-center gap-1">
+            <span>{label}</span>
+            {tooltip && <InfoTooltip text={tooltip} />}
             <span className="text-red-500">{alertLabelText}</span>
           </FormLabel>
 

--- a/src/components/calculators/Getters/UploadGetter.tsx
+++ b/src/components/calculators/Getters/UploadGetter.tsx
@@ -1,10 +1,12 @@
 import CustomDropzone from '@/components/custom/CustomDropzone';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import InfoTooltip from '@/components/ui/info-tooltip';
 
 interface UploadGetterProps {
   form: any;
   name?: string;
   label?: string;
+  tooltip?: string;
   required?: boolean;
   onFilesChange: (files: File[]) => void;
 }
@@ -13,6 +15,7 @@ export default function UploadGetter({
   form,
   name = 'files',
   label,
+  tooltip,
   required = false,
   onFilesChange,
 }: UploadGetterProps) {
@@ -23,8 +26,9 @@ export default function UploadGetter({
       render={() => (
         <FormItem className="w-full flex flex-col gap-y-[0.875rem]">
           {label && (
-            <FormLabel className="font-normal text-textBlack80 text-sm">
-              {label}
+            <FormLabel className="font-normal text-textBlack80 text-sm inline-flex items-center gap-1">
+              <span>{label}</span>
+              {tooltip && <InfoTooltip text={tooltip} />}
               {required && <span className="text-red-500 ml-1">*</span>}
             </FormLabel>
           )}

--- a/src/components/calculators/dynamic/DynamicRenderQuestion.tsx
+++ b/src/components/calculators/dynamic/DynamicRenderQuestion.tsx
@@ -8,6 +8,7 @@ import SingleSelectDropdown from '@/components/calculators/Getters/SingleSelectD
 import UploadGetter from '@/components/calculators/Getters/UploadGetter';
 import { CustomTextarea } from '@/components/custom/CustomTextarea';
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form';
+import InfoTooltip from '@/components/ui/info-tooltip';
 import { Question, StepOption } from '@/lib/calculatorApi';
 import { Option } from '@/types';
 
@@ -23,7 +24,13 @@ function mapOptionsToFrontend(options: StepOption[]): Option[] {
     label: opt.label,
     imageUrl: opt.imageUrl || undefined,
     isExclusive: opt.isExclusive,
+    tooltip: opt.hasTooltip && opt.tooltip ? opt.tooltip : undefined,
   }));
+}
+
+// Pull a question-level tooltip only when the admin has explicitly enabled it
+function questionTooltip(question: Question): string | undefined {
+  return question.hasTooltip && question.tooltip ? question.tooltip : undefined;
 }
 
 // Find exclusive option value from options list
@@ -41,12 +48,15 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
 
   const options = mapOptionsToFrontend(question.options);
 
+  const tooltip = questionTooltip(question);
+
   switch (question.type) {
     case 'SELECT':
       return (
         <SingleSelectDropdown
           name={question.id}
           label={question.question}
+          tooltip={tooltip}
           placeholder={question.placeholder || 'Selecteer een optie'}
           data={options}
           alertLabelText={question.required ? '*' : ''}
@@ -59,6 +69,7 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
         <MultiSelectDropdown
           name={question.id}
           label={question.question}
+          tooltip={tooltip}
           placeholder={question.placeholder || 'Selecteer opties'}
           data={options}
           exclusiveOption={exclusiveOption}
@@ -72,6 +83,7 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
           form={form}
           name={question.id}
           label={`${question.question}${question.unit ? ` (${question.unit})` : ''}`}
+          tooltip={tooltip}
           placeholder={question.placeholder || (question.unit ? `Voer ${question.unit} in` : 'Voer een getal in')}
           type="number"
           min={question.minValue ?? 0}
@@ -85,6 +97,7 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
           form={form}
           name={question.id}
           label={question.question}
+          tooltip={tooltip}
           placeholder={question.placeholder || 'Voer tekst in'}
           type="text"
         />
@@ -96,6 +109,7 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
           form={form}
           name={question.id}
           label={question.question}
+          tooltip={tooltip}
           placeholder={question.placeholder || 'Voer tekst in (alleen letters)'}
           type="text"
         />
@@ -107,6 +121,7 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
           form={form}
           name={question.id}
           label={question.question}
+          tooltip={tooltip}
           required={question.required}
           onFilesChange={onFilesChange || (() => {})}
         />
@@ -120,8 +135,9 @@ export default function DynamicRenderQuestion({ question, onFilesChange }: Dynam
           name={question.id}
           render={({ field, fieldState }) => (
             <FormItem className="flex flex-col gap-y-2">
-              <FormLabel className="font-normal text-textBlack80 text-sm">
-                {question.question}
+              <FormLabel className="font-normal text-textBlack80 text-sm inline-flex items-center gap-1">
+                <span>{question.question}</span>
+                {tooltip && <InfoTooltip text={tooltip} />}
                 {question.required && <span className="text-red-500">*</span>}
               </FormLabel>
               <FormControl>

--- a/src/components/ui/info-tooltip.tsx
+++ b/src/components/ui/info-tooltip.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { Info, X } from 'lucide-react';
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/utils';
+
+interface InfoTooltipProps {
+  text: string;
+  className?: string;
+  iconSize?: number;
+  ariaLabel?: string;
+}
+
+type Position = { top: number; left: number; placement: 'top' | 'bottom' };
+
+const PADDING = 12;
+const TOOLTIP_MAX_WIDTH = 260;
+
+export default function InfoTooltip({
+  text,
+  className,
+  iconSize = 14,
+  ariaLabel = 'More information',
+}: InfoTooltipProps) {
+  const [mounted, setMounted] = React.useState(false);
+  const [hovering, setHovering] = React.useState(false);
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [position, setPosition] = React.useState<Position | null>(null);
+  const [isCoarsePointer, setIsCoarsePointer] = React.useState(false);
+
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const tooltipRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    setMounted(true);
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const mq = window.matchMedia('(hover: none), (pointer: coarse)');
+      setIsCoarsePointer(mq.matches);
+      const handler = (e: MediaQueryListEvent) => setIsCoarsePointer(e.matches);
+      mq.addEventListener?.('change', handler);
+      return () => mq.removeEventListener?.('change', handler);
+    }
+  }, []);
+
+  const computePosition = React.useCallback((tooltipHeight: number): Position | null => {
+    if (!triggerRef.current || typeof window === 'undefined') return null;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const width = Math.min(TOOLTIP_MAX_WIDTH, vw - PADDING * 2);
+
+    const triggerCenterX = rect.left + rect.width / 2;
+    let left = triggerCenterX - width / 2;
+    left = Math.max(PADDING, Math.min(vw - width - PADDING, left));
+
+    const spaceAbove = rect.top - PADDING;
+    const spaceBelow = vh - rect.bottom - PADDING;
+
+    let placement: 'top' | 'bottom' = 'top';
+    let top: number;
+    if (spaceAbove >= tooltipHeight + 8 || spaceAbove >= spaceBelow) {
+      placement = 'top';
+      top = rect.top - tooltipHeight - 8;
+      if (top < PADDING) top = PADDING;
+    } else {
+      placement = 'bottom';
+      top = rect.bottom + 8;
+      if (top + tooltipHeight > vh - PADDING) {
+        top = Math.max(PADDING, vh - tooltipHeight - PADDING);
+      }
+    }
+
+    return { top, left, placement };
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!hovering) return;
+    const measure = () => {
+      const h = tooltipRef.current?.offsetHeight ?? 60;
+      const next = computePosition(h);
+      if (next) setPosition(next);
+    };
+    measure();
+  }, [hovering, computePosition, text]);
+
+  React.useEffect(() => {
+    if (!hovering) return;
+    const onScroll = () => setHovering(false);
+    const onResize = () => {
+      const h = tooltipRef.current?.offsetHeight ?? 60;
+      const next = computePosition(h);
+      if (next) setPosition(next);
+    };
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [hovering, computePosition]);
+
+  React.useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [mobileOpen]);
+
+  const handleMouseEnter = () => {
+    if (isCoarsePointer) return;
+    setHovering(true);
+  };
+
+  const handleMouseLeave = () => {
+    if (isCoarsePointer) return;
+    setHovering(false);
+  };
+
+  const handleFocus = () => {
+    if (isCoarsePointer) return;
+    setHovering(true);
+  };
+
+  const handleBlur = () => {
+    if (isCoarsePointer) return;
+    setHovering(false);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (isCoarsePointer) {
+      setMobileOpen(true);
+    } else {
+      setHovering((v) => !v);
+    }
+  };
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    e.stopPropagation();
+  };
+
+  const closeMobile = (e?: React.SyntheticEvent) => {
+    if (e) e.stopPropagation();
+    setMobileOpen(false);
+  };
+
+  if (!text) return null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={ariaLabel}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onClick={handleClick}
+        onPointerDown={handlePointerDown}
+        className={cn(
+          'inline-flex items-center justify-center rounded-full text-primaryDefault transition-colors hover:text-primaryGreenD1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primaryDefault focus-visible:ring-offset-1',
+          className
+        )}
+        style={{ width: iconSize + 4, height: iconSize + 4 }}
+      >
+        <Info style={{ width: iconSize, height: iconSize }} strokeWidth={2.25} />
+      </button>
+
+      {mounted && hovering && !isCoarsePointer && createPortal(
+        <div
+          ref={tooltipRef}
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            top: position?.top ?? -9999,
+            left: position?.left ?? -9999,
+            maxWidth: TOOLTIP_MAX_WIDTH,
+            zIndex: 9999,
+            visibility: position ? 'visible' : 'hidden',
+            pointerEvents: 'none',
+          }}
+          className="rounded-md bg-primaryDefault px-3 py-2 text-xs leading-snug text-white shadow-lg"
+        >
+          {text}
+        </div>,
+        document.body
+      )}
+
+      {mounted && mobileOpen && createPortal(
+        <div
+          role="dialog"
+          aria-modal="true"
+          onClick={closeMobile}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="fixed inset-0 z-[9999] flex items-end justify-center bg-black/60 p-4 sm:items-center"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="relative w-full max-w-sm rounded-lg bg-white p-4 pr-10 shadow-2xl"
+          >
+            <p className="text-sm leading-relaxed text-textBlack">{text}</p>
+            <button
+              type="button"
+              onClick={closeMobile}
+              aria-label="Close"
+              className="absolute top-2 right-2 flex h-8 w-8 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Button } from '@/components/ui/button';
 import { Command, CommandGroup, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
 import HoverZoomImage from '@/components/ui/hover-zoom-image';
+import InfoTooltip from '@/components/ui/info-tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
@@ -38,6 +39,7 @@ interface MultiSelectFormFieldProps
     disabled?: boolean;
     icon?: React.ComponentType<{ className?: string }>;
     imageUrl?: string;
+    tooltip?: string;
   }[];
   defaultValue?: string[];
   disabled?: boolean;
@@ -178,6 +180,11 @@ const MultiSelectFormField = React.forwardRef<HTMLButtonElement, MultiSelectForm
                         </div>
                         {option.icon && <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />}
                         <span>{option.label}</span>
+                        {option.tooltip && (
+                          <span className="ml-1.5">
+                            <InfoTooltip text={option.tooltip} />
+                          </span>
+                        )}
                       </div>
 
                       {option.imageUrl && /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(option.imageUrl) && (

--- a/src/components/ui/single-select.tsx
+++ b/src/components/ui/single-select.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { Button } from '@/components/ui/button';
 import { Command, CommandGroup, CommandItem, CommandList, CommandSeparator } from '@/components/ui/command';
 import HoverZoomImage from '@/components/ui/hover-zoom-image';
+import InfoTooltip from '@/components/ui/info-tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
@@ -19,6 +20,7 @@ export interface SingleSelectOption {
   icon?: React.ComponentType<{ className?: string }>;
   imageUrl?: string;
   disabled?: boolean; // <--- Per-item disabling
+  tooltip?: string;
 }
 
 const singleSelectVariants = cva(
@@ -159,6 +161,11 @@ const SingleSelectFormField = React.forwardRef<HTMLButtonElement, SingleSelectFo
                               <CheckIcon className={`h-4 w-4 ${isSelected ? 'text-white' : ''}`} />
                             </div>
                             <span>{option.label}</span>
+                            {option.tooltip && (
+                              <span className="ml-1.5">
+                                <InfoTooltip text={option.tooltip} />
+                              </span>
+                            )}
                           </div>
                           {option.imageUrl &&
                            /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(option.imageUrl) && (

--- a/src/lib/calculatorApi.ts
+++ b/src/lib/calculatorApi.ts
@@ -28,6 +28,8 @@ export interface StepOption {
   order: number;
   isExclusive?: boolean; // When selected, clears other selections
   priceVariants?: PriceVariants | null; // Different prices per service type
+  hasTooltip?: boolean;
+  tooltip?: string | null;
 }
 
 export interface Question {
@@ -48,6 +50,8 @@ export interface Question {
   variantSourceQuestionId?: string | null; // Which question determines the price variant
   multipliesPriceOfQuestionId?: string | null; // This question's value multiplies the price from referenced question
   conditionalOn: ConditionalOn;
+  hasTooltip?: boolean;
+  tooltip?: string | null;
   options: StepOption[];
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,7 @@ export type Option = {
   icon?: React.ComponentType<{ className?: string }>;
   disabled?: boolean;
   isExclusive?: boolean;
+  tooltip?: string;
 };
 
 export interface FormData {


### PR DESCRIPTION
… icon

- New InfoTooltip component: portal-rendered preview escapes the calculator/popover container; hover and keyboard focus on desktop, tap-to-open bottom-sheet modal on touch devices, dismiss on Esc/scroll/backdrop.
- Wired into single-select and multi-select for per-option tooltips, and into all dynamic Getters (single, multi, input, upload, fallback textarea) for per-question tooltips.
- Types extended on calculatorApi (Question, StepOption) and the shared Option type. Tooltip only renders when hasTooltip is true and tooltip text is non-empty so admins can keep text saved while hiding the icon.