### PR TITLE
fix(shop): guard against null Shopify responses in collection/product…

### DIFF
--- a/src/utils/shop/query-tools.ts
+++ b/src/utils/shop/query-tools.ts
@@ -72,7 +72,9 @@ export const getShopifyCollections = async (): Promise<Collection[]> => {
   }
 `;
   const allCollections = await shopifyRequest<{ collections: { nodes: any[] } }>(GET_COLLECTIONS_QUERY);
-  return allCollections?.collections.nodes as Collection[];
+  // shopifyRequest returns null on failure; fall back to [] so consumers can safely .map()
+  // and the static prerender doesn't crash when Shopify hiccups during build.
+  return (allCollections?.collections?.nodes ?? []) as Collection[];
 };
 
 export async function getAllProducts(): Promise<Product[]> {
@@ -151,8 +153,9 @@ export async function getAllProducts(): Promise<Product[]> {
 }`;
 
   const response = await shopifyRequest<{ products: { edges: { node: Product }[] } }>(GET_ALL_PRODUCTS_QUERY);
-  console.log('response', response?.products.edges);
-  return response?.products.edges.map((edge) => edge.node) || [];
+  // Belt-and-braces: chain the optional access all the way through so a partial response
+  // shape doesn't crash the static prerender.
+  return response?.products?.edges?.map((edge) => edge.node) ?? [];
 }
 
 export async function getProductById({ productId }: { productId: string }): Promise<Product | null> {


### PR DESCRIPTION
… helpers

shopifyRequest returns null on any failure (network, GraphQL errors, missing token), but getShopifyCollections was returning that null through as undefined, which crashed the static prerender of /products when consumers called .map(). getAllProducts had a partial guard that didn't survive a partial response shape.

Both helpers now consistently return [] on any failure, so the build no longer breaks when the Shopify API hiccups (currently returning "Not Found" during build), and consumers can rely on always receiving an array.