### PR TITLE
feat(calculator): tighten another-service step UX and refresh info icon

### DIFF
--- a/src/components/calculators/dynamic/AnotherServiceStep.tsx
+++ b/src/components/calculators/dynamic/AnotherServiceStep.tsx
@@ -5,13 +5,15 @@ import React from 'react';
 
 import CreateButton from '@/components/custom/CreateButton';
 import { HeadlineSemibold } from '@/components/theme/typography';
-import { selectCartCount, selectCartTotal, useServiceCart } from '@/store/service-cart';
+import { selectCartTotal, useServiceCart } from '@/store/service-cart';
 
 interface AnotherServiceStepProps {
   // Live total of the in-progress active service (already excluded from the cart).
   activeServiceTotal: number;
   // Whether the active service has any data we'd commit on yes.
   hasActiveService: boolean;
+  // Display name of the active service (shown in the offer-summary badge).
+  activeServiceName?: string;
   onYes: () => void;
   onNo: () => void;
   onPrevious: () => void;
@@ -23,16 +25,21 @@ interface AnotherServiceStepProps {
 export default function AnotherServiceStep({
   activeServiceTotal,
   hasActiveService,
+  activeServiceName,
   onYes,
   onNo,
   onPrevious,
   canGoBack,
 }: AnotherServiceStepProps) {
   const cartTotal = useServiceCart(selectCartTotal);
-  const cartCount = useServiceCart(selectCartCount);
+  const cartServices = useServiceCart((state) => state.services);
 
   const grandTotal = cartTotal + (hasActiveService ? activeServiceTotal : 0);
-  const totalServices = cartCount + (hasActiveService ? 1 : 0);
+  // Combined list of all service names in this quote: committed (cart) + active (if any).
+  const serviceNames = [
+    ...cartServices.map((s) => s.calculator.name),
+    ...(hasActiveService && activeServiceName ? [activeServiceName] : []),
+  ];
 
   return (
     <form className="w-[386px] flex rounded-[4px] relative lg:px-0 z-10 flex-col shadow-lg">
@@ -63,17 +70,16 @@ export default function AnotherServiceStep({
             Wilt u nog een andere dienst toevoegen?
           </p>
           <p className="font-sans text-xs text-gray-500">
-            U kunt meerdere diensten in één offerte combineren. Klik op &quot;Ja&quot; om nog een dienst toe te voegen,
-            of op &quot;Nee&quot; om door te gaan naar de planning.
+            U kunt meerdere diensten in één offerte combineren.
           </p>
         </div>
 
-        {totalServices > 0 && (
+        {serviceNames.length > 0 && (
           <div className="rounded-md bg-bgColor border border-borderGray p-3 text-xs text-textBlack80">
             <span className="font-semibold text-primaryDefault">
-              {totalServices} dienst{totalServices === 1 ? '' : 'en'}
+              {serviceNames.length === 1 ? 'Dienst' : 'Diensten'}:
             </span>{' '}
-            in deze offerte
+            {serviceNames.join(', ')}
           </div>
         )}
 

--- a/src/components/calculators/dynamic/DynamicMultiStepForm.tsx
+++ b/src/components/calculators/dynamic/DynamicMultiStepForm.tsx
@@ -974,6 +974,7 @@ export default function DynamicMultiStepForm({ calculatorSlug }: DynamicMultiSte
       <AnotherServiceStep
         activeServiceTotal={priceBreakdown?.total ?? 0}
         hasActiveService={!!calculator}
+        activeServiceName={calculator?.name}
         onYes={handleAnotherServiceYes}
         onNo={handleAnotherServiceNo}
         onPrevious={handleAnotherServicePrevious}

--- a/src/components/ui/info-tooltip.tsx
+++ b/src/components/ui/info-tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Info, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 
@@ -169,7 +169,19 @@ export default function InfoTooltip({
         )}
         style={{ width: iconSize + 4, height: iconSize + 4 }}
       >
-        <Info style={{ width: iconSize, height: iconSize }} strokeWidth={2.25} />
+        {/* Solid green disc with a white "i" — the SVG's circle uses currentColor so the
+            hover utility above can darken the whole disc together with the focus ring. */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          style={{ width: iconSize + 4, height: iconSize + 4 }}
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle cx="12" cy="12" r="12" fill="currentColor" />
+          <circle cx="12" cy="7.5" r="1.6" fill="#ffffff" />
+          <rect x="10.4" y="10.5" width="3.2" height="8.5" rx="1.6" fill="#ffffff" />
+        </svg>
       </button>
 
       {mounted && hovering && !isCoarsePointer && createPortal(


### PR DESCRIPTION
- InfoTooltip now renders a solid green disc with a white "i" instead of the previous outline icon, matching the refreshed visual brief. The whole disc darkens on hover via currentColor.
- The "another-service" badge lists actual service names ("Dienst: X" or "Diensten: X, Y") rather than a bare count, so the user can see at a glance which services are already in the quote.
- Removed the redundant "Klik op Ja/Nee..." instruction line under the question; the buttons label themselves.