### PR TITLE
fix(contact): post full contact form to /emails/contact instead of /e…

### DIFF
--- a/src/app/(root)/(routes)/contact/_components/contactFormSection.tsx
+++ b/src/app/(root)/(routes)/contact/_components/contactFormSection.tsx
@@ -112,7 +112,7 @@ const ContactForm = () => {
   });
   const { mutate, isLoading, isError, isSuccess } = useMutation({
     mutationFn: async (data: ContactFormData) => {
-      const response = await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_URL}/emails/phone`, data);
+      const response = await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_URL}/emails/contact`, data);
       console.log('response', response);
     },
     onSuccess() {


### PR DESCRIPTION
…mails/phone

The /emails/phone endpoint was originally built for the small "leave your phone number" callback widget and only forwards a couple of fields to the admin email, so submissions from the full contact form (name, last name, email, phone, message) were arriving with only the phone information.

The backend already exposes a /emails/contact endpoint that accepts the exact field shape this form sends (firstName, lastName, email, phone, message) and builds a proper email from all of them. Switching the URL is the only change required.